### PR TITLE
add workflow for validating docs using Unidoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+# This workflow validates the package’s documentation. Because documentation building involves
+# compiling the package, this also checks that the package itself compiles successfully on each
+# supported platform.
+name: documentation
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    linux:
+        runs-on: ubuntu-24.04
+        name: Ubuntu
+
+        steps:
+            -   name: Install Swift
+                uses: tayloraswift/swift-install-action@master
+                with:
+                    swift-prefix: "swift-6.0.1-release/ubuntu2404/swift-6.0.1-RELEASE"
+                    swift-id: "swift-6.0.1-RELEASE-ubuntu24.04"
+
+            -   name: Install Unidoc
+                uses: tayloraswift/swift-unidoc-action@master
+
+            #   This clobbers everything in the current directory!
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Validate documentation
+                run: |
+                    unidoc compile -I .. \
+                    --swift-toolchain $SWIFT_INSTALLATION \
+                    --ci fail-on-errors \
+                    --package-name articles
+
+    macos:
+        runs-on: macos-15
+        name: macOS
+        steps:
+            -   name: Install Unidoc
+                uses: tayloraswift/swift-unidoc-action@master
+
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Validate documentation
+                run: |
+                    unidoc compile -I .. \
+                    --ci fail-on-errors \
+                    --package-name articles


### PR DESCRIPTION
this PR adds a boilerplate `docs.yml` which runs Unidoc on GitHub Actions on the repo, with `--ci fail-on-errors`.

running the pipeline right now will probably **not** succeed, as the last time i built the repo, there were several validation errors.