### PR TITLE
Update default branch name for articles repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,9 @@ name: documentation
 
 on:
     push:
-        branches: [ master ]
+        branches: [ main ]
     pull_request:
-        branches: [ master ]
+        branches: [ main ]
 
 jobs:
     linux:


### PR DESCRIPTION
oops, it looks like the workflow isn’t running because i forgot to substitute the default branch name of this repo, which is `main` instead of `master`