### PR TITLE
make the CI green for the first time ever

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,4 +51,5 @@ jobs:
                 run: |
                     unidoc compile -I .. \
                     --ci fail-on-errors \
-                    --package-name articles
+                    --package-name articles \
+                    --define DARWIN

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "7a41c20c25866064f22b2bfa2c8194083e7e1595",
-        "version" : "2.6.1"
+        "revision" : "480f29f074878cd258b615225acf9049f94f52c3",
+        "version" : "2.6.2"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
-        "version" : "1.3.0"
+        "revision" : "ae33e5941bb88d88538d0a6b19ca0b01e6c76dcf",
+        "version" : "1.3.1"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "1fbb6ef21f1525ed5faf4c95207b9c11bea27e94",
-        "version" : "1.6.1"
+        "revision" : "274f8668d3ec5d2892904d8465635c5ea659f767",
+        "version" : "1.7.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "6483d340853a944c96dbcc28b27dd10b6c581703",
-        "version" : "1.1.2"
+        "revision" : "a64a0abc2530f767af15dd88dda7f64d5f1ff9de",
+        "version" : "1.2.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/swift-jobs.git",
       "state" : {
-        "revision" : "6aeb0a179567b944ecf81e1bbfdd474c1ee171f1",
-        "version" : "1.0.0-beta.6"
+        "revision" : "1fb1585ef88b3b74f190e6f8d390ad47987651e1",
+        "version" : "1.0.0-beta.7"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "e0165b53d49b413dd987526b641e05e246782685",
-        "version" : "2.5.0"
+        "revision" : "5e63558d12e0267782019f5dadfcae83a7d06e09",
+        "version" : "2.5.1"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
-        "version" : "2.77.0"
+        "revision" : "ba72f31e11275fc5bf060c966cf6c1f36842a291",
+        "version" : "2.79.0"
       }
     },
     {

--- a/Sources/Articles/Documentation.docc/2024/logging-for-server-side-swift-apps/logging-for-server-side-swift-apps.md
+++ b/Sources/Articles/Documentation.docc/2024/logging-for-server-side-swift-apps/logging-for-server-side-swift-apps.md
@@ -562,9 +562,9 @@ Define a custom environment variable based on your identifier:
 
 e.g.: `my-library` -> `MY_LIBRARY_LOG_LEVEL`
 
-The ``setenv(_:_:_:)`` function can be used to define environmental variables from Swift code.
+The ``setenv(_:_:_:) [ignore when: DARWIN]`` function can be used to define environmental variables from Swift code.
 
-Important: Avoid utilizing the ``setenv(_:_:_:)`` function. It is intended solely for demonstration purposes.
+Important: Avoid utilizing the ``setenv(_:_:_:) [ignore when: DARWIN]`` function. It is intended solely for demonstration purposes.
 
 Run the project from the command line, using the following command to explicitly set environment variables:
 

--- a/Sources/Articles/Documentation.docc/2025/jwt-kit/jwt-kit.md
+++ b/Sources/Articles/Documentation.docc/2025/jwt-kit/jwt-kit.md
@@ -70,10 +70,10 @@ Once you have a ``JWTKeyCollection`` object, you can use it to "create" a JWT. C
 
 @Snippet(path: "site/Snippets/jwt-kit", slice: payload_struct)
 
-In this example, we define a ``TestPayload`` struct that conforms to the ``JWTPayload`` protocol. This protocol requires us to implement the ``JWTPayload/verify(using:)`` method, which includes optional additional validation logic that can be performed when creating the JWT. In this case, we're verifying that the token has not expired.
-The properties of the struct are the claims we want to include in the JWT. JWTKit provides a number of built-in claims, such as ``ExpirationClaim`` and ``IssuerClaim``, which are commonly used in JWTs. JWTKit supports the [seven registered claims](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1) defined in the JWT specification, but you can also define custom claims if needed. 
+In this example, we define a `TestPayload` struct that conforms to the ``JWTPayload`` protocol. This protocol requires us to implement the ``JWTPayload/verify(using:)`` method, which includes optional additional validation logic that can be performed when creating the JWT. In this case, we're verifying that the token has not expired.
+The properties of the struct are the claims we want to include in the JWT. JWTKit provides a number of built-in claims, such as ``ExpirationClaim`` and ``IssuerClaim``, which are commonly used in JWTs. JWTKit supports the [seven registered claims](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1) defined in the JWT specification, but you can also define custom claims if needed.
 
-> Note: In the example, ``CodingKeys`` are defined to map Swift property names to the JSON keys used in the JWT. This means that in the JWT the expiration claim will be named `exp` and the issuer claim will be named `iss`, as per the JWT specification.
+> Note: In the example, `CodingKeys` are defined to map Swift property names to the JSON keys used in the JWT. This means that in the JWT the expiration claim will be named `exp` and the issuer claim will be named `iss`, as per the JWT specification.
 
 To create a JWT with this payload, you can create a new instance of the payload and use the key collection to sign it:
 
@@ -105,13 +105,13 @@ First, we'll create a payload struct that contains the user's information:
 
 @Snippet(path: "site/Snippets/jwt-kit", slice: auth_user_payload)
 
-The `UserPayload` struct represents the claims we want to include in the JWT. In this snippet, we include the user's ID, an expiration claim, and a list of roles. 
+The `UserPayload` struct represents the claims we want to include in the JWT. In this snippet, we include the user's ID, an expiration claim, and a list of roles.
 The ``JWTPayload/verify(using:)`` method checks that the token has not expired and that the user is an admin. The `init` method creates a new payload from a `User` object, which could be retrieved from a database, for example.
 The roles claim is a custom claim:
 
 @Snippet(path: "site/Snippets/jwt-kit", slice: auth_user_role_claim)
 
-This is a simple struct that conforms to the ``JWTClaim`` protocol. The ``value`` property is the value of the claim, which in this case is a list of roles.
+This is a simple struct that conforms to the ``JWTClaim`` protocol. The ``JWTClaim/value`` property is the value of the claim, which in this case is a list of roles.
 Next, we'll create a route that handles user logins and returns a JWT:
 
 @Snippet(path: "site/Snippets/jwt-kit", slice: auth_user_payload)


### PR DESCRIPTION
this makes use of a new feature in Unidoc 0.21.0 which enables passing `--define` strings through `unidoc compile`, which can then be used to suppress broken symbol link diagnostics

i also fixed the broken links in the JWT article